### PR TITLE
Religious clothing overrides

### DIFF
--- a/src/PortraitBuilder.Online/BlobLoader.cs
+++ b/src/PortraitBuilder.Online/BlobLoader.cs
@@ -23,7 +23,7 @@ namespace PortraitBuilder.Online
             return storage.CreateCloudBlobClient();
         });
 
-        internal static readonly Lazy<ValueTask<PortraitData>> _portraitPack = new Lazy<ValueTask<PortraitData>>(async () =>
+        internal static readonly Lazy<Task<PortraitData>> _portraitPack = new Lazy<Task<PortraitData>>(async () =>
         {
             var client = _storageClient.Value;
 
@@ -35,7 +35,7 @@ namespace PortraitBuilder.Online
             return JsonSerializer.Deserialize<PortraitData>(json, options);
         });
 
-        internal static readonly Lazy<ValueTask<IReadOnlyDictionary<string, IEnumerable<string>>>> _cultureLookup = new Lazy<ValueTask<IReadOnlyDictionary<string, IEnumerable<string>>>>(async () =>
+        internal static readonly Lazy<Task<IReadOnlyDictionary<string, IEnumerable<string>>>> _cultureLookup = new Lazy<Task<IReadOnlyDictionary<string, IEnumerable<string>>>>(async () =>
         {
             var client = _storageClient.Value;
 

--- a/src/PortraitBuilder.Online/Models/Character.cs
+++ b/src/PortraitBuilder.Online/Models/Character.cs
@@ -15,5 +15,7 @@ namespace PortraitBuilder.Online.Models
         public int? Year { get; set; }
         public string? Rank { get; set; }
         public string? Government { get; set; }
+        public string? Religion { get; set; }
+        public bool? ReligiousHead { get; set; }
     }
 }

--- a/src/PortraitBuilder.Online/Portrait.cs
+++ b/src/PortraitBuilder.Online/Portrait.cs
@@ -63,6 +63,22 @@ namespace PortraitBuilder.Online
                 character.IsChild = age < 16;
             }
 
+            var religiousLookup = await _religiousClothingLookup.Value;
+            if (characterModel.Religion != null && religiousLookup.TryGetValue(characterModel.Religion, out (int, int) clothingInfo))
+            {
+                var religiousClothingHead = clothingInfo.Item1;
+                var religiousClothingPriest = clothingInfo.Item2;
+
+                if (characterModel.ReligiousHead.GetValueOrDefault())
+                {
+                    character.ReligiousClothingOverride = religiousClothingHead;
+                }
+                else if (character.Government == GovernmentType.Theocracy)
+                {
+                    character.ReligiousClothingOverride = religiousClothingPriest;
+                }
+            }
+
             PortraitType portraitType = default;
             var fallbacks = new List<PortraitType>();
             foreach (var graphicalCulture in cultureLookup[characterModel.Culture])
@@ -158,7 +174,7 @@ namespace PortraitBuilder.Online
 
             using var portraitBitmap = await DrawPortraitInternal(character);
             using var portraitPixmap = portraitBitmap.PeekPixels();
-            
+
             var portraitPng = portraitPixmap.Encode(SKPngEncoderOptions.Default);
             return new FileStreamResult(portraitPng.AsStream(), "image/png");
         }

--- a/src/PortraitBuilder.Shared/Engine/PortraitBuilder.cs
+++ b/src/PortraitBuilder.Shared/Engine/PortraitBuilder.cs
@@ -145,7 +145,13 @@ namespace PortraitBuilder.Engine
                 return false;
             }
 
-            tileIndex = Character.GetIndex(letter, frameCount);
+            if(character.ReligiousClothingOverride.HasValue && layer.Characteristic == DefaultCharacteristics.HEADGEAR)
+            {
+                tileIndex = character.ReligiousClothingOverride.Value;
+            } else
+            {
+                tileIndex = Character.GetIndex(letter, frameCount);
+            }
             logger.LogDebug($"Layer letter: {letter}, Tile Index: {tileIndex}");
 
             return true;

--- a/src/PortraitBuilder.Shared/Model/Portrait/Character.cs
+++ b/src/PortraitBuilder.Shared/Model/Portrait/Character.cs
@@ -19,6 +19,8 @@ namespace PortraitBuilder.Model.Portrait
 
         public bool IsChild { get; set; }
 
+        public int? ReligiousClothingOverride { get; set; }
+
         /// <summary>
         /// Index of rank in border sprite
         /// </summary>

--- a/src/PortraitBuilder.Shared/Model/Portrait/Layer.cs
+++ b/src/PortraitBuilder.Shared/Model/Portrait/Layer.cs
@@ -36,7 +36,7 @@ namespace PortraitBuilder.Model.Portrait
         /// 6 = headgear behind hairlayer
         /// 7 = headgear hairlayer
         /// </summary>
-        public int? CultureIndex { get; set; }
+        public int CultureIndex { get; set; } = -1;
 
         /// <summary>
         /// Whether this layer should apply hair coloration 

--- a/src/PortraitBuilder.Shared/Model/Portrait/PortraitTypeExtensions.cs
+++ b/src/PortraitBuilder.Shared/Model/Portrait/PortraitTypeExtensions.cs
@@ -28,10 +28,10 @@ namespace PortraitBuilder.Model.Portrait
 
             foreach (Layer baseLayer in basePortraitType.Layers)
             {
-                Layer mergeLayer = baseLayer;
-                if (baseLayer.CultureIndex.HasValue)
+                var mergeLayer = baseLayer;
+                if (baseLayer.CultureIndex != -1)
                 {
-                    var overrideLayer = clothingPortraitType.GetCultureLayer(baseLayer.CultureIndex.Value);
+                    var overrideLayer = clothingPortraitType.GetCultureLayer(baseLayer.CultureIndex);
                     if (overrideLayer != null)
                     {
                         logger.LogDebug("Overriding layer {0} with {1}", baseLayer, overrideLayer);
@@ -46,7 +46,6 @@ namespace PortraitBuilder.Model.Portrait
                         };
                     }
                 }
-
                 mergedPortraitType.Layers.Add(mergeLayer);
             }
 


### PR DESCRIPTION
This release also fixes two major regressions:
* Merged portraits, like those created when specifying a clothing type to `/portrait/`, were incorrectly selecting layer indexes.
* `ValueTask`s were used for cached properties, causing them to be fetched every time. See [Prefer ValueTask to Task, always; and don't await twice ](https://blog.marcgravell.com/2019/08/prefer-valuetask-to-task-always-and.html).